### PR TITLE
Apply Undead/Construct modifiers to unshaken roll

### DIFF
--- a/scripts/class/Char.js
+++ b/scripts/class/Char.js
@@ -53,6 +53,16 @@ export default class Char {
         }
     }
 
+    hasAbilitySetting(abilityName){
+        
+        let ability=this.getActor().items.filter(el=>el.type=='ability' && el.name.trim()==gb.settingKeyName(abilityName).trim());
+        if (ability && ability.length>0){
+            return true;
+        } else {
+            return false;
+        }
+    }
+
     data(key){ // after data.data
       //  console.log(this.getActor());
        // console.log(key,this.getActor().data[key]);

--- a/scripts/class/CharRoll.js
+++ b/scripts/class/CharRoll.js
@@ -40,6 +40,7 @@ export default class CharRoll extends BasicRoll{
        this.flagUpdate={};
 
        this.edgemod=0;
+       this.abilityMod=0;
        this.vehicle=false;
 
       
@@ -87,6 +88,16 @@ export default class CharRoll extends BasicRoll{
             if (char.hasEdgeSetting(edge)){
                 this.addModifier(mod,gb.settingKeyName(edge))
                 this.edgemod=mod;
+            }
+        }
+    }
+
+    addAbilityModifier(ability,mod){
+        if (mod>this.abilityMod){
+            let char=new Char(this.actor);
+            if (char.hasAbilitySetting(ability)){
+                this.addModifier(mod,gb.settingKeyName(ability))
+                this.abilityMod=mod;
             }
         }
     }

--- a/scripts/class/CombatControl.js
+++ b/scripts/class/CombatControl.js
@@ -150,8 +150,8 @@ export default class CombatControl {
         
 
         charRoll.addEdgeModifier('Combat Reflexes',2)
-        charRoll.addEdgeModifier('Undead',2)
-        charRoll.addEdgeModifier('Construct',2)
+        charRoll.addAbilityModifier('Undead',2)
+        charRoll.addAbilityModifier('Construct',2)
 
 
         


### PR DESCRIPTION
Look for the Undead or Construct abilities, rather than edges. This will make SWADE Tools compatible with tokens from the SWADE Core Rules official ruleset, or the Savage Pathfinder core ruleset or bestiary, which use Undead and Construct as abilities, not edges.