### PR TITLE
add Formation Fighter from Savage Worlds Pathfinder

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -143,6 +143,7 @@
     "SWADETOOLS.BlockSetting": "Block",
     "SWADETOOLS.ImprovedBlockSetting": "Improved Block",
     "SWADETOOLS.FrenzySetting": "Frenzy",
+    "SWADETOOLS.FormationFighterSetting": "Formation Fighter",
     "SWADETOOLS.SettingShowSituational": "Always show Situational Modifiers for target",
     "SWADETOOLS.SettingShowSituationalHint": "With this option checked, targets' modifiers will be always visible, no need to click at (?)"
     

--- a/scripts/class/RollControl.js
+++ b/scripts/class/RollControl.js
@@ -1197,7 +1197,12 @@ export default class RollControl {
 
         console.log('helping',helping_target);
 
-        let gangup=allies_of_attacker.length-helping_target;
+        let formation_allies_of_attacker = allies_of_attacker.filter(al=>{
+            let alChar = new Char(al)
+            return alChar.hasEdgeSetting('Formation Fighter')
+        })
+
+        let gangup=allies_of_attacker.length+formation_allies_of_attacker.length-helping_target;
 
         if (gangup>4){
             gangup=4

--- a/scripts/gb.js
+++ b/scripts/gb.js
@@ -6,7 +6,7 @@ export const moduleName='swade-tools'
 
 
 export const attributes=['agility','smarts','spirit','strength','vigor']
-export const edgesNaming=['Elan','No Mercy','Iron Jaw','Combat Reflexes','Dodge','Block','Improved Block','Frenzy'];
+export const edgesNaming=['Elan','No Mercy','Iron Jaw','Combat Reflexes','Dodge','Block','Improved Block','Frenzy', 'Formation Fighter'];
 export const abilitiesNaming=['Construct','Hardy','Undead'];
 export const settingRules=['Dumb Luck','Hard Choices','Unarmored Hero','Wound Cap'];
 


### PR DESCRIPTION
When acting as the ally of an attacker, a character with Formation
Fighter will add +2 to the gangup bonus instead of +1. Max gangup bonus
is still +4.