### PR TITLE
Add free reroll button to chat card

### DIFF
--- a/css/swadetools.css
+++ b/css/swadetools.css
@@ -102,6 +102,11 @@ button.swadetools-rollbutton {
     justify-content: center;
 }
 
+button.swadetools-freereroll {
+    position: absolute;
+    right: calc(1.5em + 6px);
+    bottom: 0;
+}
 
 button.swadetools-bennyrerroll {
    

--- a/lang/en.json
+++ b/lang/en.json
@@ -35,6 +35,7 @@
     "SWADETOOLS.NoActorFoundReroll": "No Actor was found to spend the Benny (or there are actors with the same name), spend the benny and reroll manually",
     "SWADETOOLS.CriticalFailure": "Critical Failure!",
     "SWADETOOLS.RerollBtn": "Reroll Spending a Benny",
+    "SWADETOOLS.FreeRerollBtn": "Free Reroll",
     "SWADETOOLS.AutoInitWarn": "This is enabled by default when using SWADE Tools, but it's disabled in the system configs to avoid conflict",
     "SWADETOOLS.Fighting": "Fighting",
     "SWADETOOLS.SettingFighting": "Fighting Skill Name",

--- a/scripts/class/RollControl.js
+++ b/scripts/class/RollControl.js
@@ -222,6 +222,7 @@ export default class RollControl {
             this.html.append('<div class="swadetools-relative"><div class="swadetools-rollbuttonwrap"></div></div>');
             if (!this.isCritical() || gb.settingKeyName('Dumb Luck')){
                 this.addBennyButton();
+                this.addFreeRerollButton();
             }
 
             if (!this.isCritical()){
@@ -1351,12 +1352,22 @@ export default class RollControl {
     }
 
 
-    
+    addFreeRerollButton() {
+        this.html.find('.swadetools-relative .swadetools-rollbuttonwrap').
+            append('<button class="swadetools-freereroll swadetools-rollbutton" title="' +
+                   gb.trans('FreeRerollBtn') +
+                   '"><i class="fa fa-redo"></i></button>').
+            on('click', 'button.swadetools-freereroll', () => {
+                let actor=this.findActor();
+
+                if (actor) {
+                    this.rerollBasic(actor, false);
+                }
+            }
+        );
+    } 
 
     addBennyButton(){
-
-        
-
         if (this.rolltype!='unshaken'){ /// dont show benny button for unshaken roll
         this.html.find('.swadetools-relative .swadetools-rollbuttonwrap').append('<button class="swadetools-bennyrerroll swadetools-rollbutton" title="'+gb.trans('RerollBtn')+'"></button>').on('click','button.swadetools-bennyrerroll',()=>{
             
@@ -1373,7 +1384,7 @@ export default class RollControl {
                
 
 
-                this.rerollBasic(actor);
+                this.rerollBasic(actor, true);
                
                 
             
@@ -1403,7 +1414,7 @@ export default class RollControl {
         }
     }
 
-    rerollBasic(actor){
+    rerollBasic(actor, usedBenny){
 
         let char=new Char(actor);
         let mod=0;
@@ -1411,26 +1422,24 @@ export default class RollControl {
         let edgebonus=false;
         let oldroll=this.chat._roll
 
+        //  console.log(this.chat.data.flags);
+        if (usedBenny) {
+            if (this.rolltype=='damage'){
 
-      //  console.log(this.chat.data.flags);
+                if (this.chat.data.flags['swade-tools']?.edgebonus!="nomercy" && char.hasEdgeSetting('No Mercy')){
+                    mod=2
+                    reason=gb.settingKeyName('No Mercy');
+                    edgebonus='nomercy'
+                }
 
-        if (this.rolltype=='damage'){
-
-            if (this.chat.data.flags['swade-tools']?.edgebonus!="nomercy" && char.hasEdgeSetting('No Mercy')){
-                mod=2
-                reason=gb.settingKeyName('No Mercy');
-                edgebonus='nomercy'
-            }
-
-        } else {
-            if (this.chat.data.flags['swade-tools']?.edgebonus!="elan" && char.hasEdgeSetting('Elan')){
-                mod=2
-                reason=gb.settingKeyName('Elan');    
-                edgebonus='elan'
+            } else {
+                if (this.chat.data.flags['swade-tools']?.edgebonus!="elan" && char.hasEdgeSetting('Elan')){
+                    mod=2
+                    reason=gb.settingKeyName('Elan');    
+                    edgebonus='elan'
+                }
             }
         }
-
-       
 
        let modStr='';
        let extraflavor='';


### PR DESCRIPTION
Add a button for free-reroll to the roll results chat card. This facilitates the full swade-tools experience for the many free-rerolls called for in Savage Pathfinder.