### PR TITLE
Allow Up to 4 Damage Dice

### DIFF
--- a/scripts/gb.js
+++ b/scripts/gb.js
@@ -242,7 +242,7 @@ export const stringMod=(mod)=>{
 
 
 export const explodeAllDice=(weaponDamage)=>{
-    let regexDiceExplode = /d[0-9]{1,2}/g;
+    let regexDiceExplode = /d[0-9]{1,4}/g;
     weaponDamage = weaponDamage.replace(/x|=/g,'') /// remove x and = if it already has
     weaponDamage = weaponDamage.replace(regexDiceExplode, "$&x");
     return weaponDamage;


### PR DESCRIPTION
Changed the limit of damage dice from 2 to 4 to play nicer with modules like Savage Rifts (can have multiples of attributes as damage dice)
![image_2022-10-12_081330469](https://user-images.githubusercontent.com/605616/195339678-ced5864d-0a62-4785-8d95-c7a4d70c681f.png)
