### PR TITLE
Fixed combat start/end automation bug

### DIFF
--- a/scripts/class/CharRoll.js
+++ b/scripts/class/CharRoll.js
@@ -732,7 +732,7 @@ export default class CharRoll extends BasicRoll{
         let combatant=gb.actorCombatant(this.actor)
       //  console.log(this.actor,combatant.id,'wild');
         if (combatant){
-            await gb.setFlagCombatant(game.combat,combatant,gb.moduleName,'removeVulnerable',0);
+            await gb.setFlagCombatant(game.combat,combatant,gb.moduleName,'removeVulnerable',false);   //EternalRider: I don't know why the 0 in my test will not work
         }
     }
 

--- a/scripts/class/CombatControl.js
+++ b/scripts/class/CombatControl.js
@@ -7,15 +7,16 @@ export default class CombatControl {
     
 
     constructor(){
-        this.previousTurn=false;   
-        this.combatid=false;  
-        this.combatinfo={}
-        this.acting=false;
+        // this.previousTurn=false;   //EternalRider: useless
+        // this.combatid=false;  //EternalRider: useless
+        // this.combatinfo={}  //EternalRider: useless
+        // this.acting=false; //EternalRider: this.acting is not always the previous combatant
        
        // this.combatant=false;   
     }
 
-    setCombat(id){
+    //EternalRider: useless
+    /* setCombat(id){
         if (this.combatid!=id){ /// changed combat
             this.previousTurn=false;
 
@@ -27,10 +28,11 @@ export default class CombatControl {
         this.combatid=id;
 
         
-    }
+    } */
 
 
-    isNewTurn(){
+    //EternalRider: useless
+    /* isNewTurn(){
         let combat= game.combats.get(this.combatid);
         gb.log('SWADETOOLS','C2',combat,this.combatinfo);
         if (this.combatinfo.round!=combat.current.round || this.combatinfo.turn!=combat.current.turn){
@@ -42,7 +44,7 @@ export default class CombatControl {
         } else {
             return false;
         }
-    }
+    } */
    
     /* async act(combatant){ ///not used anymore
         
@@ -91,7 +93,8 @@ export default class CombatControl {
 
       //  let update={_id:combatant.id,['flags.'+scope+'.'+flag]:value}
       //  console.log(update);
-      gb.setFlagCombatant(game.combats.get(this.combatid),combatant,scope,flag,value);
+    //   gb.setFlagCombatant(game.combats.get(this.combatid),combatant,scope,flag,value);  //EternalRider: this.combatid has many bug
+    gb.setFlagCombatant(combatant.combat,combatant,scope,flag,value);  //EternalRider: just use combat from combatant itself
       //  game.combats.get(this.combatid).updateCombatant(update);
     }
 
@@ -269,11 +272,16 @@ export default class CombatControl {
         return
     }
    // console.log(combatant);
+      if (combatant){
+        //EternalRider: Do not retrigger
+        let hasStarted = await this.getFlag(combatant, gb.moduleName, 'hasStarted');
+        if (hasStarted) return;
+        await this.setFlag(combatant, gb.moduleName, 'hasStarted', true);
         let actor=combatant.actor;
         
     gb.log('start: '+actor.name); 
 
-        this.acting=combatant;
+        // this.acting=combatant; //EternalRider: this.acting is not always the previous combatant
         let char=new Char(actor);
         let checkDistracted=true;
         let checkVulnerable=true;
@@ -304,13 +312,13 @@ export default class CombatControl {
         
         /// Distracted
         if (checkDistracted && char.is('isDistracted')){
-            this.setFlag(combatant,gb.moduleName,'removeDistracted',1)
+            this.setFlag(combatant,gb.moduleName,'removeDistracted',true)  //EternalRider: I don't know why the 0 in my test will not work
            // combatant.setFlag(gb.moduleName,'removeDistracted',1);
         }
 
         /// Vulnerable
         if (checkVulnerable && char.is('isVulnerable')){
-            this.setFlag(combatant,gb.moduleName,'removeVulnerable',1)
+            this.setFlag(combatant,gb.moduleName,'removeVulnerable',true)  //EternalRider: I don't know why the 0 in my test will not work
             //combatant.setFlag(gb.moduleName,'removeVulnerable',1);
         }
 
@@ -321,18 +329,24 @@ export default class CombatControl {
 
         /// Entangled
     }
+    }
     
-    async endTurn(){
+    async endTurn(combatant){  //EternalRider: same as startTurn is better
 
         
       //  console.log(combatant);
-      let combatant=this.acting;
+    //   let combatant=this.acting; //EternalRider: this.acting is not always the previous combatant
 
       if (combatant.defeated){ //do nothing if it's defeated
         return
     }
 
       if (combatant){
+        //EternalRider: Do not retrigger
+        let hasEnded = await this.getFlag(combatant, gb.moduleName, 'hasEnded');
+        if (hasEnded) return;
+        await this.setFlag(combatant, gb.moduleName, 'hasEnded', true);
+
         let actor=combatant.actor;
     gb.log('end: '+actor.name); 
         let char=new Char(actor);
@@ -347,14 +361,14 @@ export default class CombatControl {
          //   console.log('removing Vulnerable');
             char.off('isVulnerable')
             char.say(gb.trans("RemVuln"))
-            this.setFlag(combatant,gb.moduleName,'removeVulnerable',0)
+            this.setFlag(combatant,gb.moduleName,'removeVulnerable',false)  //EternalRider: I don't know why the 0 in my test will not work
         }
 
         let removeDist=await this.getFlag(combatant,gb.moduleName,'removeDistracted');
         if (removeDist){
             char.off('isDistracted');
             char.say(gb.trans("RemDistr"))
-            this.setFlag(combatant,gb.moduleName,'removeDistracted',0)
+            this.setFlag(combatant,gb.moduleName,'removeDistracted',false)  //EternalRider: I don't know why the 0 in my test will not work
         }
 
         if (gb.actorIsConvicted(actor.id)){

--- a/scripts/class/RollControl.js
+++ b/scripts/class/RollControl.js
@@ -376,7 +376,7 @@ export default class RollControl {
                    // actor.update({'data.status.isDistracted':true,'data.status.isVulnerable':true})
                 },500)
               //  char.updateData({'status.isDistracted':false,'status.isVulnerable':true})/// just to make sure is disabled
-              gb.setFlagCombatant(game.combats.get(this.chat.flags?.["swade-tools"]?.usecombat),{id:this.chat.flags?.["swade-tools"]?.usecombatant},'swade-tools','removeVulnerable',1)
+              gb.setFlagCombatant(game.combats.get(this.chat.flags?.["swade-tools"]?.usecombat),{id:this.chat.flags?.["swade-tools"]?.usecombatant},'swade-tools','removeVulnerable',true)   //EternalRider: I don't know why the 0 in my test will not work
             //    game.combats.get(this.chat.data.flags?.["swade-tools"]?.usecombat).updateCombatant({_id:this.chat.data.flags?.["swade-tools"]?.usecombatant,['flags.swade-tools.removeVulnerable']:1});
               //  actor.update({'data.status.isDistracted':false,'data.status.isVulnerable':false}) /// just to make sure is disabled
             }

--- a/scripts/gb.js
+++ b/scripts/gb.js
@@ -1227,3 +1227,28 @@ export const btnAction = { /// button functions
     }
     
 }
+
+/**
+ * 等待直到给定的函数返回true，或者达到最大迭代次数
+ * @param {() => boolean} fn 要等待的函数，返回true时停止等待
+ * @param {number} maxIter 最大迭代次数
+ * @param {number} iterWaitTime 每次迭代的等待时间
+ * @param {number} i 迭代次数
+ * @returns {Promise<boolean>} 是否等待成功
+ */
+export async function waitFor(fn, maxIter = 600, iterWaitTime = 100, i = 0) {
+    const continueWait = (current, max) => {
+      /* negative max iter means wait forever */
+      // 负的最大迭代次数表示无限等待
+      if (maxIter < 0) return true;
+      return current < max;
+    }
+  
+    while (!fn(i, ((i * iterWaitTime) / 100)) && continueWait(i, maxIter)) {
+      // 当函数返回false，并且还未达到最大迭代次数时，执行以下操作
+      i++;
+      await warpgate.wait(iterWaitTime);
+    }
+    // 如果达到最大迭代次数，则返回false，否则返回true
+    return i === maxIter ? false : true;
+  }

--- a/scripts/start.js
+++ b/scripts/start.js
@@ -482,14 +482,14 @@ let cbt=new CombatControl;
 
 
 
-Hooks.on('combatTurn', async (combat,data) => 
+Hooks.on('combatTurn', async (combat,data,options) => 
 {
-   // 
+    if (options.direction == -1) return;  //EternalRider: Do not retrigger
    // console.log(JSON.parse(JSON.stringify(data.turn)));
     
-    cbt.setCombat(combat.id);
+    // cbt.setCombat(combat.id); //EternalRider: useless
    // const currentCombatant=await combat.current.combatantId;
-    await cbt.endTurn();
+    await cbt.endTurn(combat.turns[data.turn - 1]);  //EternalRider: with no backforward, just use minus 1
 
     await cbt.startTurn(combat.turns[data.turn]);
 
@@ -499,10 +499,12 @@ Hooks.on('combatTurn', async (combat,data) =>
    //  console.log(combat,data);
 })
 
-Hooks.on('combatRound',async (combat) => {
-    cbt.setCombat(combat.id);
+Hooks.on('combatRound',async (combat,data,options) => {
+    if (options.direction == -1) return;  //EternalRider: Do not retrigger
+    // cbt.setCombat(combat.id); //EternalRider: useless
     // const currentCombatant=await combat.current.combatantId;
 
+    /* EternalRider: hooks will not be called in right times, so we need to wait for all combatants to have their initiative set
     let helpHook=Hooks.on('updateCombat', async(combatdata)=>{
 
         let itgo=true;
@@ -518,9 +520,28 @@ Hooks.on('combatRound',async (combat) => {
             Hooks.off('updateCombat',helpHook)
         }
    
-    })
+    })*/
     
+    //EternalRider: store this before it has been changed
+    let previous = combat.combatants.get(combat?.previous?.combatantId);
+    //EternalRider: clean up retrigger tag when new round starts
+    for (let turner of combat.turns) {
+        await cbt.setFlag(turner, gb.moduleName, 'hasStarted', false);
+        await cbt.setFlag(turner, gb.moduleName, 'hasEnded', false);
+    }
+    //EternalRider: wait for all combatants to have their initiative set
+    await gb.waitFor(() => {
+        return combat.turns.every(turner => turner.initiative !== null);
+    }, -1);
+    //EternalRider: then trigger the end and start turn
+    await cbt.endTurn(previous);
+    await cbt.startTurn(combat.turns[0]);
 })
+
+//EternalRider: don't forget to start the first turn
+Hooks.on("combatStart", async (combat, data) => {
+    await cbt.startTurn(combat.turns[data.turn]);
+});
 
 // Hooks.on('updateCombat',async (entity,data,options,userid)=>{
 //   //  console.log(JSON.parse(JSON.stringify(entity)))


### PR DESCRIPTION
1.补上了战斗开始时的第一个回合的Hook；
2.令endTurn函数使用正确的combatant；
3.使用combatant自身的combat对象，以支持同时存在多遭遇的情况，以及修复在战斗过程中掉线重连时CombatControl对象重建导致丢失id的问题；
4.使用更准确的Boolean进行逻辑判断；
5.使用hasStarted和hasEnded标记以避免同一轮内调整combatant顺序时重复触发；
——————
1. made up the Hook for the first turn at the start of the battle;
2. made the endTurn function use the correct combatant;
3. using the combatant's own combat object to support the simultaneous existence of multiple encounters, as well as fixing a problem with CombatControl objects rebuilding when disconnecting and reconnecting during combat that resulted in lost ids;
4. use more accurate Boolean for logical judgement;
5. using hasStarted and hasEnded flags to avoid repeated triggers when adjusting combatant order within the same round;

Translated with DeepL.com (free version)